### PR TITLE
Fix grammar in model assumptions

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -75,7 +75,7 @@ const assumptions = [
   'Maximum AK sweep have been capped at 50 degrees. Based on our analysis, we believe that higher levels of astigmatism should be treated with toric lenses over laser AKs (>= 0.60 ATR or >= 1.1 WTR)',
   'The nomogram assumes a clear corneal temporal incision with a 2.4-2.8mm blade which can be assumed to create ~0.2 D of SIA at 180 deg. An "average" SIA has been captured by the weights during the machine learning process. Inputting a presumed SIA for an individual surgeon has not been shown to significantly improve results.',
   'The model treats low levels of anterior ATR astigmatism aggressively in order to mitigate the effects of posterior corneal astigmatism and known regression of treatment effect at these axes.',
-  'The current iteration of this model was been trained using K readings and other measurements from the IOLMaster 700 (Zeiss Meditec).'
+  'The current iteration of this model has been trained using K readings and other measurements from the IOLMaster 700 (Zeiss Meditec).'
 ]
 </script>
 


### PR DESCRIPTION
## Summary
- fix grammar in assumptions: "was been trained" -> "has been trained"

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0400abf58832aac4c0298076c0844